### PR TITLE
Local address, Owned Servers only, Server data overhaul

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -20,7 +20,8 @@ namespace PlexampRPC {
     [GlobalConfig]
     public class Config : SettingsManager<Config> {
         public bool UpdateChecker { get; set; } = true;
-        
+        public bool LocalAddress { get; set; } = false;
+
         public int ArtResolution { get; set; } = 128;
         public double RefreshInterval { get; set; } = 2.5;
         public int SessionTimeout { get; set; } = 30;
@@ -52,9 +53,9 @@ namespace PlexampRPC {
 
         public static string? Token { get; set; }
         public static PlexAccount? Account { get; set; }
-        public static AccountServerContainer? ServerContainer { get; set; }
+        public static Resource[]? PlexResources { get; set; }
 
-        public static LogWriter? Log { get; set; } 
+        public static LogWriter? Log { get; set; }
 
         public App() {
             Config.Load();
@@ -119,10 +120,10 @@ namespace PlexampRPC {
 
             try {
                 Account = await AccountClient.GetPlexAccountAsync(Token);
-                ServerContainer = await AccountClient.GetAccountServersAsync(Token);
+                PlexResources = await Resource.GetAccountResources();
             }
-            catch { 
-                _ = PlexSignIn(true); 
+            catch {
+                _ = PlexSignIn(true);
             }
         }
 

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -23,6 +23,7 @@ namespace PlexampRPC {
         public bool UpdateChecker { get; set; } = true;
         public bool LocalAddress { get; set; } = false;
         public List<String> Skipped { get; set; } = new();
+        public bool OwnedOnly { get; set; } = false;
 
         public int ArtResolution { get; set; } = 128;
         public double RefreshInterval { get; set; } = 2.5;

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -14,6 +14,7 @@ using Plex.ServerApi.PlexModels.Account;
 using Plex.ServerApi.PlexModels.OAuth;
 using DyviniaUtils;
 using DyviniaUtils.Dialogs;
+using System.Collections.Generic;
 
 namespace PlexampRPC {
 
@@ -21,6 +22,7 @@ namespace PlexampRPC {
     public class Config : SettingsManager<Config> {
         public bool UpdateChecker { get; set; } = true;
         public bool LocalAddress { get; set; } = false;
+        public List<String> Skipped { get; set; } = new();
 
         public int ArtResolution { get; set; } = 128;
         public double RefreshInterval { get; set; } = 2.5;

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -23,7 +23,7 @@ namespace PlexampRPC {
         public bool UpdateChecker { get; set; } = true;
         public bool LocalAddress { get; set; } = false;
         public List<String> Skipped { get; set; } = new();
-        public bool OwnedOnly { get; set; } = false;
+        public bool OwnedOnly { get; set; } = true;
 
         public int ArtResolution { get; set; } = 128;
         public double RefreshInterval { get; set; } = 2.5;

--- a/Resource.cs
+++ b/Resource.cs
@@ -124,6 +124,8 @@ namespace PlexampRPC {
 
                 for (int i = 0; i < source_resources.Length; i++) {
                     Resource resource = source_resources[i];
+                    if (Config.Settings.OwnedOnly && !resource.Owned)
+                        continue;
                     MainWindow.UserNameText = $"Testing {i+1}/{source_resources.Length}";
                     Resource? r = await TestResource(resource);
                     if (r != null)

--- a/Resource.cs
+++ b/Resource.cs
@@ -115,31 +115,32 @@ namespace PlexampRPC {
                 sendResponse.EnsureSuccessStatusCode();
 
                 JsonDocument responseJson = JsonDocument.Parse(await sendResponse.Content.ReadAsStringAsync());
-                Resource[]? source_resources = JsonSerializer.Deserialize<Resource[]>(responseJson.RootElement);
-                List<Resource>? filtered_resources = new();
-                if (source_resources == null || source_resources.Length == 0) {
+                Resource[]? sourceResources = JsonSerializer.Deserialize<Resource[]>(responseJson.RootElement);
+                List<Resource>? filteredResources = new();
+                if (sourceResources == null || sourceResources.Length == 0) {
                     Console.WriteLine("WARN: No servers found");
                     return null;
                 }
 
-                for (int i = 0; i < source_resources.Length; i++) {
-                    Resource resource = source_resources[i];
+                int i = 1;
+                foreach (Resource resource in sourceResources) {
                     if (Config.Settings.OwnedOnly && !resource.Owned)
                         continue;
-                    MainWindow.UserNameText = $"Testing {i+1}/{source_resources.Length}";
-                    Resource? r = await TestResource(resource);
+                    MainWindow.UserNameText = $"Testing {i}/{sourceResources.Length}";
+                    Resource? r = await testResource(resource);
                     if (r != null)
-                        filtered_resources.Add(r);
+                        filteredResources.Add(r);
+                    i += 1;
                 }
 
-                return filtered_resources.ToArray();
+                return filteredResources.ToArray();
             } catch (Exception e) {
                 Console.WriteLine($"WARN: Unable to get resource: {e.Message} {e.InnerException}");
                 return null;
             }
         }
 
-        public static async Task<Resource?> TestResource(Resource resource) {
+        private static async Task<Resource?> testResource(Resource resource) {
             if (!(resource.Provides ?? "").Split(",").Contains("server")) {
                 Console.WriteLine($"INFO: Skipping {resource.Name}/{resource.Product}, not a server");
                 return null;

--- a/Resource.cs
+++ b/Resource.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace PlexampRPC {
+    public class Connection {
+        [JsonPropertyName("protocol")]
+        public string? Protocol { get; set; }
+
+        [JsonPropertyName("address")]
+        public string? Address { get; set; }
+
+        [JsonPropertyName("port")]
+        public int Port { get; set; }
+
+        [JsonPropertyName("uri")]
+        public string? Uri { get; set; }
+
+        [JsonPropertyName("local")]
+        public bool Local { get; set; }
+
+        [JsonPropertyName("relay")]
+        public bool Relay { get; set; }
+
+        [JsonPropertyName("IPv6")]
+        public bool IPv6 { get; set; }
+    }
+
+    public class Resource {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("product")]
+        public string? Product { get; set; }
+
+        [JsonPropertyName("productVersion")]
+        public string? ProductVersion { get; set; }
+
+        [JsonPropertyName("platform")]
+        public string? Platform { get; set; }
+
+        [JsonPropertyName("platformVersion")]
+        public string? PlatformVersion { get; set; }
+
+        [JsonPropertyName("device")]
+        public string? Device { get; set; }
+
+        [JsonPropertyName("clientIdentifier")]
+        public string? ClientIdentifier { get; set; }
+
+        [JsonPropertyName("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonPropertyName("lastSeenAt")]
+        public DateTime LastSeenAt { get; set; }
+
+        [JsonPropertyName("provides")]
+        public string? Provides { get; set; }
+
+        [JsonPropertyName("ownerId")]
+        public int? OwnerId { get; set; }
+
+        [JsonPropertyName("sourceTitle")]
+        public string? SourceTitle { get; set; }
+
+        [JsonPropertyName("publicAddress")]
+        public string? PublicAddress { get; set; }
+
+        [JsonPropertyName("accessToken")]
+        public string? AccessToken { get; set; }
+
+        [JsonPropertyName("owned")]
+        public bool Owned { get; set; }
+
+        [JsonPropertyName("home")]
+        public bool Home { get; set; }
+
+        [JsonPropertyName("synced")]
+        public bool Synced { get; set; }
+
+        [JsonPropertyName("relay")]
+        public bool Relay { get; set; }
+
+        [JsonPropertyName("presence")]
+        public bool Presence { get; set; }
+
+        [JsonPropertyName("httpsRequired")]
+        public bool HttpsRequired { get; set; }
+
+        [JsonPropertyName("publicAddressMatches")]
+        public bool PublicAddressMatches { get; set; }
+
+        [JsonPropertyName("dnsRebindingProtection")]
+        public bool DnsRebindingProtection { get; set; }
+
+        [JsonPropertyName("natLoopbackSupported")]
+        public bool NatLoopbackSupported { get; set; }
+
+        [JsonPropertyName("connections")]
+        public IList<Connection>? Connections { get; set; }
+        public Uri? LocalUri { get; set; }
+        public Uri? Uri { get; set; }
+
+        public static async Task<Resource[]?> GetAccountResources() {
+            try {
+                HttpRequestMessage requestMessage = new(HttpMethod.Get, $"https://plex.tv/api/v2/resources?includeHttps=1&includeIPv6=1&X-Plex-Token={App.Token}&X-Plex-Client-Identifier=PlexampRPC");
+                requestMessage.Headers.Add("Accept", "application/json");
+
+                HttpResponseMessage sendResponse = await MainWindow.httpClient.SendAsync(requestMessage);
+                sendResponse.EnsureSuccessStatusCode();
+
+                JsonDocument responseJson = JsonDocument.Parse(await sendResponse.Content.ReadAsStringAsync());
+                Resource[]? source_resources = JsonSerializer.Deserialize<Resource[]>(responseJson.RootElement);
+                List<Resource>? filtered_resources = new List<Resource>();
+
+                for (int i = 0; i < source_resources?.Length; i++) {
+                    Resource? r = await TestResource(source_resources[i]);
+                    if (r != null)
+                        filtered_resources.Add(r);
+                }
+
+                return filtered_resources.ToArray();
+            } catch (Exception e) {
+                Console.WriteLine($"WARN: Unable to get resource: {e.Message} {e.InnerException}");
+                return null;
+            }
+        }
+
+        public static async Task<Resource?> TestResource(Resource resource) {
+            if (!(resource.Provides ?? "").Split(",").Contains("server")) {
+                Console.WriteLine($"INFO: Skipping {resource.Name}/{resource.Product}, not a server");
+                return null;
+            }
+            TimeSpan TimeoutBackup = MainWindow.httpClient.Timeout;
+            if (Config.Settings.LocalAddress)
+                MainWindow.httpClient.Timeout = TimeSpan.FromSeconds(1);
+            foreach (Connection connection in resource.Connections ?? Enumerable.Empty<Connection>()) {
+                Uri Uri;
+                if (connection.Local)
+                    Uri = new UriBuilder("http", connection.Address, connection.Port).Uri;
+                else
+                    Uri = new UriBuilder(connection.Uri).Uri;
+                try {
+                    Console.WriteLine($"INFO: Testing {(connection.Local ? 'L' : 'R')} {Uri}status/sessions?X-Plex-Token={resource.AccessToken?.Substring(0, 3)}...");
+                    HttpRequestMessage requestMessage = new(HttpMethod.Get, $"{Uri}status/sessions?X-Plex-Token={resource.AccessToken}");
+                    requestMessage.Headers.Add("Accept", "application/json");
+
+                    HttpResponseMessage sendResponse = await MainWindow.httpClient.SendAsync(requestMessage);
+                    sendResponse.EnsureSuccessStatusCode();
+                    Console.WriteLine($"INFO: Success {(connection.Local ? 'L' : 'R')} {Uri}status/sessions?X-Plex-Token={resource.AccessToken?.Substring(0, 3)}...");
+                    if (connection.Local)
+                        resource.LocalUri ??= Uri;
+                    else
+                        resource.Uri ??= Uri;
+                    if (resource.LocalUri != null && resource.Uri != null) {
+
+                    }
+                } catch (TaskCanceledException) {
+                    Console.WriteLine($"WARN: Timeout {(connection.Local ? 'L' : 'R')} {Uri}status/sessions?X-Plex-Token={resource.AccessToken?.Substring(0, 3)}...");
+                    // Unreachable local server, skip
+                } catch (HttpRequestException e) {
+                    Console.WriteLine($"WARN: Unable to access {Uri}status/sessions: {e.Message}");
+                    if (e.StatusCode == HttpStatusCode.Forbidden) break;
+                } catch (Exception e) {
+                    Console.WriteLine($"WARN: Unable to get resource: {e.Message} {e.InnerException}");
+                }
+            }
+            MainWindow.httpClient.Timeout = TimeoutBackup;
+            if (resource.LocalUri == null && resource.Uri == null)
+                return null;
+            return resource;
+        }
+    }
+}

--- a/SessionData.cs
+++ b/SessionData.cs
@@ -40,6 +40,8 @@ namespace PlexampRPC {
             public string? Name { get; set; }
         }
 
+        [JsonPropertyName("guid")]
+        public string? Guid { get; set; }
 
         public PlayerData? Player { get; set; }
         public class PlayerData {

--- a/Utils/Dialogs/UpdateDialog.xaml.cs
+++ b/Utils/Dialogs/UpdateDialog.xaml.cs
@@ -59,7 +59,7 @@ namespace DyviniaUtils.Dialogs {
         }
 
         private void Browser_Navigating(object sender, NavigatingCancelEventArgs e) {
-            if (e.Uri is null) return;
+            if (e.Uri == null) return;
 
             if (e.Uri.ToString().StartsWith("http")) {
                 e.Cancel = true;

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -80,7 +80,7 @@
                 </Image>
 
                 <StackPanel x:Name="UserInfoPanel" Grid.Column="1" VerticalAlignment="Center" Margin="4" >
-                    <TextBlock x:Name="UserNameText" Text="User" Foreground="#FFF1F1F1" Width="150" FontSize="16" Height="20" FontWeight="Bold" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                    <TextBlock x:Name="UserNameTextBox" Text="{x:Static local:MainWindow.UserNameText}" Foreground="#FFF1F1F1" Width="150" FontSize="16" Height="20" FontWeight="Bold" HorizontalAlignment="Left" VerticalAlignment="Top"/>
                     <ComboBox x:Name="UserServerComboBox" Width="150" DisplayMemberPath="Name" Margin="0 4 0 0"/>
                 </StackPanel>
             </Grid>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -216,7 +216,7 @@ namespace PlexampRPC {
                 ArtLink = await GetThumbnail(session.ArtPath),
                 State = session.Player?.State,
                 TimeOffset = session.ViewOffset,
-                Url = $"https://listen.plex.tv/{session.Guid?[7..]}" // plex://type/id
+                Url = (session.Guid != null && session.Guid.StartsWith("plex://")) ? $"https://listen.plex.tv/{session.Guid?[7..]}" : null
             };
         }
 
@@ -230,9 +230,9 @@ namespace PlexampRPC {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = presence.ImageTooltip
                     },
-                    Buttons = new Button[] {
+                    Buttons = presence.Url != null ? new Button[] {
                         new Button() { Label = "More...", Url = presence.Url }
-                    }
+                    } : null
                 });
 
                 PreviewArt.Source = new BitmapImage(new Uri(presence.ArtLink));

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -50,14 +50,14 @@ namespace PlexampRPC {
             set {
                 if (_userNameText != value) {
                     _userNameText = value;
-                    UpdateUserNameTextBlock(value);
+                    updateUserNameTextBlock(value);
                 }
             }
         }
 
         private static string _userNameText = "Logging in...";
 
-        private static void UpdateUserNameTextBlock(string newText) {
+        private static void updateUserNameTextBlock(string newText) {
             Application.Current.Dispatcher.Invoke(() =>
             {
                 if (Application.Current.MainWindow is MainWindow mainWindow) {

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Input;
 using System.Windows.Media.Imaging;
 using DiscordRPC;
 using Hardcodet.Wpf.TaskbarNotification;
+using Button = DiscordRPC.Button;
 
 namespace PlexampRPC {
     /// <summary>
@@ -76,6 +77,7 @@ namespace PlexampRPC {
             public string ArtLink { get; set; } = "https://raw.githubusercontent.com/Dyvinia/PlexampRPC/master/Resources/PlexIconSquare.png";
             public string? State { get; set; }
             public int TimeOffset { get; set; }
+            public string? Url { get; set; }
         }
 
         public MainWindow() {
@@ -213,7 +215,8 @@ namespace PlexampRPC {
                 ImageTooltip = session.Album?.Length > 2 ? session.Album : session.Album + "  ",
                 ArtLink = await GetThumbnail(session.ArtPath),
                 State = session.Player?.State,
-                TimeOffset = session.ViewOffset
+                TimeOffset = session.ViewOffset,
+                Url = $"https://listen.plex.tv/{session.Guid?[7..]}" // plex://type/id
             };
         }
 
@@ -226,6 +229,9 @@ namespace PlexampRPC {
                     Assets = new() {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = presence.ImageTooltip
+                    },
+                    Buttons = new Button[] {
+                        new Button() { Label = "More...", Url = presence.Url }
                     }
                 });
 

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -190,10 +190,6 @@ namespace PlexampRPC {
 
                 return sessions?.FirstOrDefault(session => session.Type == "track" && session.User?.Name == App.Account?.Username);
             }
-            catch (KeyNotFoundException) {
-                // Nothing is playing
-                return null;
-            }
             catch (Exception e) {
                 Console.WriteLine($"WARN: Unable to get current session: {Address}status/sessions?X-Plex-Token={Token?[..3]}... {e.Message} {e.InnerException}");
                 return null;

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -34,7 +34,9 @@
 
                     <CheckBox x:Name="StartupCheckBox" Margin="0 5 0 0" Content="Start on Startup" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts"/>
 
-                    <CheckBox x:Name="LocalCheckBox" Margin="0 5 0 0" Content="Use Local Address" IsChecked="{Binding Path=(local:Config.LocalAddress), Mode=TwoWay}" ToolTip="Use the local address to connect to a given Plex server"/>
+                    <CheckBox x:Name="LocalCheckBox" Margin="0 5 0 0" Content="Use Local Address" IsChecked="{Binding Path=(local:Config.LocalAddress), Mode=TwoWay}" ToolTip="Use the Plex server's local IP and port"/>
+
+                    <CheckBox x:Name="OwnedCheckBox" Margin="0 5 0 0" Content="Owned Servers Only" IsChecked="{Binding Path=(local:Config.OwnedOnly), Mode=TwoWay}" ToolTip="Only adds servers to the list that belong to the authenticated Plex user"/>
 
                 </StackPanel>
                 <Grid Height="15"/>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -31,9 +31,11 @@
                     </DockPanel>
 
                     <CheckBox x:Name="CheckUpdatesCheckBox" Margin="0 5 0 0" Content="Check for Updates" IsChecked="{Binding Path=(local:Config.UpdateChecker), Mode=TwoWay}" ToolTip="Checks Github for Updates"/>
-                    
+
                     <CheckBox x:Name="StartupCheckBox" Margin="0 5 0 0" Content="Start on Startup" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts"/>
-                    
+
+                    <CheckBox x:Name="LocalCheckBox" Margin="0 5 0 0" Content="Use Local Address" IsChecked="{Binding Path=(local:Config.LocalAddress), Mode=TwoWay}" ToolTip="Use the local address to connect to a given Plex server"/>
+
                 </StackPanel>
                 <Grid Height="15"/>
                 <StackPanel>


### PR DESCRIPTION
Fixes #8

I've replaced AccountServerContainer entirely with an array of [Resource](https://plexapi.dev/docs/plex-tv/get-devices)s, this contains a great deal more useful information, one of which is all addresses the server expects to be getting requests on.

It takes a while longer to start the application now, as it checks each server to see if it can be reached with the provided information and whether /status/sessions is accessible. If it isn't, the server is removed from the list entirely. I have access to six libraries on my account but I only have access to /status/sessions on my own so there's no point in showing the others. The time it takes to iterate through these is somewhat annoying. Actually, now I'm typing this, I realise I can catch the 401 Unauthorized and skip that resource entirely, that'll be easier. brb

---

Okay, I did that, also cleaned up the whole thing a lot, adhered to your existing code style for the project. And actually now I've had another idea.. This is how life has been for the last couple weeks, I just started ADHD meds and I can't stop having ideas and writing code. So I'm going to put this up here since it satisfies #8, but I'm adding more feedback for the user as shown:

![image](https://github.com/Dyvinia/PlexampRPC/assets/63546997/5b2ec96e-43c0-488b-be2e-f0a87b5463db)

Because staring at a loading spinner with no feedback is boring.

Also I sincerely apologise if this is way more like a blog post than a PR; I'm getting back into coding and posting my code and I'm used to typing like I talk.