### PR TITLE
Checkbox to display media other than music from Plex session

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -24,6 +24,7 @@ namespace PlexampRPC {
         public bool LocalAddress { get; set; } = false;
         public List<String> Skipped { get; set; } = new();
         public bool OwnedOnly { get; set; } = true;
+        public bool AllMedia { get; set; } = false;
 
         public int ArtResolution { get; set; } = 128;
         public double RefreshInterval { get; set; } = 2.5;

--- a/SessionData.cs
+++ b/SessionData.cs
@@ -14,7 +14,7 @@ namespace PlexampRPC {
 
         public string? Artists {
             get {
-                string artists = TrackArtist ?? AlbumArtist ?? "Artist";
+                string artists = TrackArtist ?? AlbumArtist ?? "Plex";
                 if (artists.Contains(';')) {
                     string[] artistList = artists.Split(';', StringSplitOptions.TrimEntries);
                     if (artistList.Length > 2)

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -190,7 +190,15 @@ namespace PlexampRPC {
 
                 SessionData[]? sessions = JsonSerializer.Deserialize<SessionData[]>(responseJson.RootElement.GetProperty("MediaContainer").GetProperty("Metadata"));
 
-                return sessions?.FirstOrDefault(session => session.Type == "track" && session.User?.Name == App.Account?.Username);
+                List<String> matchTypes = new() {
+                    "track"
+                };
+                if (Config.Settings.AllMedia) {
+                    matchTypes.Add("episode");
+                    matchTypes.Add("movie");
+                }
+
+                return sessions?.FirstOrDefault(session => session.Type != null && matchTypes.Contains(session.Type) && session.User?.Name == App.Account?.Username);
             }
             catch (Exception e) {
                 Console.WriteLine($"WARN: Unable to get current session: {Address}status/sessions?X-Plex-Token={Token?[..3]}... {e.Message} {e.InnerException}");

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -38,6 +38,8 @@
 
                     <CheckBox x:Name="OwnedCheckBox" Margin="0 5 0 0" Content="Owned Servers Only" IsChecked="{Binding Path=(local:Config.OwnedOnly), Mode=TwoWay}" ToolTip="Only adds servers to the list that belong to the authenticated Plex user"/>
 
+                    <CheckBox x:Name="AllMediaCheckBox" Margin="0 5 0 0" Content="Show All Media" IsChecked="{Binding Path=(local:Config.AllMedia), Mode=TwoWay}" ToolTip="Include TV shows and Movies in content shown on Discord, not just Music"/>
+
                 </StackPanel>
                 <Grid Height="15"/>
                 <StackPanel>


### PR DESCRIPTION
![image](https://github.com/Dyvinia/PlexampRPC/assets/63546997/99fea37d-cded-4bff-9dc7-c999cb3532b6)
![image](https://github.com/Dyvinia/PlexampRPC/assets/63546997/b18b7d29-1ccb-4094-a58a-379fc984b685)

This was an idea I had a couple days ago, totally fine if it's out of spec for PlexampRPC, I just think it's a neat feature to have to show people what show or movie I'm watching as well as what music I'm listening to.