### PR TITLE
Use "Listening" activity type, add end timestamp

### DIFF
--- a/PlexampRPC.csproj
+++ b/PlexampRPC.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
+    <PackageReference Include="DiscordRichPresence" Version="1.3.0.28" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Plex.Api" Version="4.1.2" />

--- a/SessionData.cs
+++ b/SessionData.cs
@@ -52,5 +52,8 @@ namespace PlexampRPC {
 
         [JsonPropertyName("viewOffset")]
         public int ViewOffset { get; set; }
+
+        [JsonPropertyName("duration")]
+        public int Duration { get; set; }
     }
 }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -77,6 +77,7 @@ namespace PlexampRPC {
             public string ArtLink { get; set; } = "https://raw.githubusercontent.com/Dyvinia/PlexampRPC/master/Resources/PlexIconSquare.png";
             public string? State { get; set; }
             public int TimeOffset { get; set; }
+            public int Duration { get; set; }
             public string? Url { get; set; }
         }
 
@@ -216,6 +217,7 @@ namespace PlexampRPC {
                 ArtLink = await GetThumbnail(session.ArtPath),
                 State = session.Player?.State,
                 TimeOffset = session.ViewOffset,
+                Duration = session.Duration,
                 Url = (session.Guid != null && session.Guid.StartsWith("plex://")) ? $"https://listen.plex.tv/{session.Guid?[7..]}" : null
             };
         }
@@ -225,7 +227,8 @@ namespace PlexampRPC {
                 App.DiscordClient.SetPresence(new RichPresence() {
                     Details = TrimUTF8String(presence.Line1!), // theres probably a better way to trim strings but idk
                     State = TrimUTF8String(presence.Line2!),
-                    Timestamps = new(DateTime.UtcNow.AddMilliseconds(-(double)presence.TimeOffset)),
+                    Timestamps = new(DateTime.UtcNow.AddMilliseconds(-(double)presence.TimeOffset), DateTime.UtcNow.AddMilliseconds((double)presence.Duration-(double)presence.TimeOffset)),
+                    Type = ActivityType.Listening,
                     Assets = new() {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = presence.ImageTooltip
@@ -249,6 +252,7 @@ namespace PlexampRPC {
                 App.DiscordClient.SetPresence(new RichPresence() {
                     Details = TrimUTF8String(presence.Line1!),
                     State = TrimUTF8String(presence.Line2!),
+                    Type = ActivityType.Listening,
                     Assets = new() {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = presence.ImageTooltip,


### PR DESCRIPTION
[RPC now supports specifying Activity Type](https://github.com/Lachee/discord-rpc-csharp/commit/a52326776575d34ed14080e7b7781e607d99680b) and rpc-csharp has a prerelease that supports this functionality (I had to add it locally as it's not on nuget yet, first time working with C# windows applications so I wasn't really sure what I was doing). Also, a time bar similar to spotify presence will show on listening activities if you specify an end timestamp. Thankfully, Plex provides a duration value, making this end timestamp easy to determine.
![image](https://github.com/user-attachments/assets/2895f4f1-a1d7-46d7-a759-2b7a105c3385)