### PR TITLE
Add "Start in Tray" setting

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -86,16 +86,29 @@ namespace PlexampRPC
             DispatcherUnhandledException += ExceptionDialog.UnhandledException;
         }
 
-        protected override async void OnStartup(StartupEventArgs e) {
-            MainWindow window = new();
-            window.Show();
+        protected override async void OnStartup(StartupEventArgs e)
+        {
+            bool startInTray = e.Args.Contains("--tray");
+
+            MainWindow window = new(startInTray); // Pass flag to constructor
+            MainWindow = window;
+
+            if (!startInTray)
+            {
+                window.Show();
+                window.WindowState = WindowState.Normal;
+                window.Activate();
+            }
+            else
+            {
+                window.WindowState = WindowState.Minimized;
+                window.ShowInTaskbar = false;
+                window.Hide();
+            }
 
             await PlexSignIn();
             window.UpdateAccountIcon();
             PlexResources = await window.GetAccountResources();
-
-            window.WindowState = WindowState.Normal;
-            window.Activate();
             window.GetAccountInfo();
             window.StartPolling();
 
@@ -106,7 +119,6 @@ namespace PlexampRPC
             if (Config.Settings.UpdateChecker)
                 await GitHub.CheckAndInstall("Dyvinia", "PlexampRPC");
         }
-
         protected override void OnExit(ExitEventArgs e) {
             DiscordClient.Dispose();
 

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -48,7 +48,8 @@ namespace PlexampRPC
             public string? Url { get; set; }
         }
 
-        public MainWindow() {
+        public MainWindow(bool startInTray = false)
+        {
             InitializeComponent();
 
             httpClient.Timeout = TimeSpan.FromSeconds(2);
@@ -57,7 +58,8 @@ namespace PlexampRPC
             MouseDown += (_, _) => FocusManager.SetFocusedElement(this, this);
 
             StateChanged += (_, _) => {
-                if (WindowState == WindowState.Minimized) {
+                if (WindowState == WindowState.Minimized)
+                {
                     Hide();
                     TrayIcon.ShowBalloonTip(null, "Minimized to Tray", BalloonIcon.None);
                 }
@@ -67,6 +69,14 @@ namespace PlexampRPC
             SetupTray();
 
             PreviewListeningTo.Text = $"Listening to {Config.Settings.DiscordListeningTo}";
+
+            if (startInTray)
+            {
+                // Minimize to tray at startup
+                WindowState = WindowState.Minimized;
+                ShowInTaskbar = false;
+                Hide();
+            }
         }
 
         public TaskbarIcon TrayIcon = new() {

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -33,7 +33,7 @@
                     <CheckBox x:Name="CheckUpdatesCheckBox" Margin="0 2 0 0" Content="Check for Updates" IsChecked="{Binding Path=(local:Config.UpdateChecker), Mode=TwoWay}" ToolTip="Checks Github for Updates"/>
 
                     <CheckBox x:Name="StartupCheckBox" Margin="0 0 0 0" Content="Start on Startup" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts"/>
-
+                    <CheckBox x:Name="TrayStartupCheckBox" Margin="0 0 0 0" Content="Start in Tray" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts in the tray" />
                     <CheckBox x:Name="LocalCheckBox" Margin="0 0 0 0" Content="Use Local Address" IsChecked="{Binding Path=(local:Config.LocalAddress), Mode=TwoWay}" ToolTip="Use the Plex server's local IP and port"/>
 
                     <CheckBox x:Name="OwnedCheckBox" Margin="0 0 0 0" Content="Owned Servers Only" IsChecked="{Binding Path=(local:Config.OwnedOnly), Mode=TwoWay}" ToolTip="Only adds servers to the list that belong to the authenticated Plex user"/>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -31,9 +31,8 @@
                     </DockPanel>
 
                     <CheckBox x:Name="CheckUpdatesCheckBox" Margin="0 2 0 0" Content="Check for Updates" IsChecked="{Binding Path=(local:Config.UpdateChecker), Mode=TwoWay}" ToolTip="Checks Github for Updates"/>
-
                     <CheckBox x:Name="StartupCheckBox" Margin="0 0 0 0" Content="Start on Startup" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts"/>
-                    <CheckBox x:Name="TrayStartupCheckBox" Margin="0 0 0 0" Content="Start in Tray" IsChecked="False" ToolTip="Start PlexampRPC when Windows starts in the tray" />
+                    <CheckBox x:Name="TrayStartupCheckBox" Margin="0 0 0 0" Content="Start in Tray" IsChecked="False" ToolTip="Start PlexampRPC in the tray when Windows starts" />
                     <CheckBox x:Name="LocalCheckBox" Margin="0 0 0 0" Content="Use Local Address" IsChecked="{Binding Path=(local:Config.LocalAddress), Mode=TwoWay}" ToolTip="Use the Plex server's local IP and port"/>
 
                     <CheckBox x:Name="OwnedCheckBox" Margin="0 0 0 0" Content="Owned Servers Only" IsChecked="{Binding Path=(local:Config.OwnedOnly), Mode=TwoWay}" ToolTip="Only adds servers to the list that belong to the authenticated Plex user"/>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -92,12 +92,31 @@ namespace PlexampRPC {
             shortcut.Save();
         }
 
-        private void CheckForStartup() {
-            if (File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"))) {
-                StartupCheckBox.IsChecked = true;
-            }
-        }
+        private void CheckForStartup()
+        {
+            string shortcutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk");
 
+            if (File.Exists(shortcutPath))
+            {
+                StartupCheckBox.IsChecked = true;
+
+                // Read the shortcut and check if it includes the "--tray" argument
+                IWshRuntimeLibrary.WshShell shell = new();
+                IWshRuntimeLibrary.IWshShortcut shortcut = (IWshRuntimeLibrary.IWshShortcut)shell.CreateShortcut(shortcutPath);
+
+                if (shortcut.Arguments?.Contains("--tray") == true)
+                    TrayStartupCheckBox.IsChecked = true;
+                else
+                    TrayStartupCheckBox.IsChecked = false;
+            }
+            else
+            {
+                StartupCheckBox.IsChecked = false;
+                TrayStartupCheckBox.IsChecked = false;
+            }
+
+            TrayStartupCheckBox.IsEnabled = StartupCheckBox.IsChecked == true;
+        }
         protected override void OnKeyDown(KeyEventArgs e) {
             base.OnKeyDown(e);
 

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -38,8 +38,6 @@ namespace PlexampRPC {
             DataContext = Config.Settings;
         }
 
-
-
         private void SetupListeningTo() {
             RadioListeningPlexamp.Checked += (_, _) => Config.Settings.DiscordListeningTo = "Plexamp";
             RadioListeningMusic.Checked += (_, _) => Config.Settings.DiscordListeningTo = "Music";

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -7,15 +7,29 @@ namespace PlexampRPC {
     /// <summary>
     /// Interaction logic for SettingsWindow.xaml
     /// </summary>
-    public partial class SettingsWindow : Window {
-        public SettingsWindow() {
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow()
+        {
             InitializeComponent();
 
             Title += $" {App.Version}";
 
             CheckForStartup();
-            StartupCheckBox.Checked += (_, _) => StartOnStartup();
-            StartupCheckBox.Unchecked += (_, _) => File.Delete(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"));
+            StartupCheckBox.Checked += (_, _) => {
+                StartOnStartup();
+                TrayStartupCheckBox.IsEnabled = true;
+            };
+            StartupCheckBox.Unchecked += (_, _) => {
+                File.Delete(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"));
+                TrayStartupCheckBox.IsEnabled = false;
+                TrayStartupCheckBox.IsChecked = false;
+            };
+
+            // Set initial enabled state based on current setting
+            TrayStartupCheckBox.IsEnabled = StartupCheckBox.IsChecked == true;
+            if (StartupCheckBox.IsChecked != true)
+                TrayStartupCheckBox.IsChecked = false;
 
             SetupListeningTo();
 
@@ -23,6 +37,8 @@ namespace PlexampRPC {
 
             DataContext = Config.Settings;
         }
+
+
 
         private void SetupListeningTo() {
             RadioListeningPlexamp.Checked += (_, _) => Config.Settings.DiscordListeningTo = "Plexamp";
@@ -38,6 +54,15 @@ namespace PlexampRPC {
         }
 
         private void StartOnStartup() {
+            IWshRuntimeLibrary.WshShell wshShell = new();
+            IWshRuntimeLibrary.IWshShortcut shortcut = wshShell.CreateShortcut(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"));
+            shortcut.TargetPath = Environment.ProcessPath;
+            shortcut.WorkingDirectory = Environment.CurrentDirectory;
+            shortcut.Save();
+        }
+
+        private void TrayOnStartup()
+        {
             IWshRuntimeLibrary.WshShell wshShell = new();
             IWshRuntimeLibrary.IWshShortcut shortcut = wshShell.CreateShortcut(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"));
             shortcut.TargetPath = Environment.ProcessPath;


### PR DESCRIPTION
This PR adds a "Start in Tray" setting.

I hacked this change a while back but I saw you pushing updates recently so I was going to see if this could add to source. I tried to make all changes coherent and align with your logic.

This change adds a "--tray" launch flag. The "--tray" flag is inserted into the shortcut file target if the setting is checked. Similar to how you manage persistence for "Start on Startup"; this looks for the "--tray" flag in the shortcut file itself. Logic is in place to ensure that this setting cannot be checked and activated without "Start on Startup" also being checked.

This is my first PR EVER! Im new to GitHub so hopefully I am doing everything correctly. sorry for the blank PR request initially. 