### PR TITLE
Add option for status display type

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -32,13 +32,14 @@ namespace PlexampRPC
         public int SessionTimeout { get; set; } = 30;
 
         public string TemplateL1 { get; set; } = "{title}";
-        public string TemplateL2 { get; set; } = "by {artist}";
+        public string TemplateL2 { get; set; } = "{artist}";
         public string TemplateL3 { get; set; } = "{album}";
 
         public string DiscordListeningTo { get; set; } = "Plexamp";
         public string DiscordCustomClientID { get; set; } = "1100233636491563069";
 
         public string PlexAddress { get; set; } = string.Empty;
+        public string StatusDisplayType { get; set; } = "Name";
     }
 
 

--- a/PlexampRPC.csproj
+++ b/PlexampRPC.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.3.0.28" />
+    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
     <PackageReference Include="Plex.Api" Version="4.1.2" />

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -65,8 +65,6 @@ namespace PlexampRPC
 
             ResetPresence();
             SetupTray();
-
-            PreviewListeningTo.Text = $"Listening to {Config.Settings.DiscordListeningTo}";
         }
 
         public TaskbarIcon TrayIcon = new() {
@@ -209,7 +207,9 @@ namespace PlexampRPC
                     State = TrimUTF8String(presence.Line2!),
                     Timestamps = new(DateTime.UtcNow.AddMilliseconds(-(double)presence.TimeOffset), DateTime.UtcNow.AddMilliseconds((double)presence.Duration-(double)presence.TimeOffset)),
                     Type = ActivityType.Listening,
-                    Assets = new() {
+                    StatusDisplay = Enum.Parse<StatusDisplayType>(Config.Settings.StatusDisplayType),
+                    Assets = new()
+                    {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = TrimUTF8String(presence.ImageTooltip!)
                     }
@@ -219,6 +219,14 @@ namespace PlexampRPC
                 PreviewL1.Text = TrimUTF8String(presence.Line1!);
                 PreviewL2.Text = TrimUTF8String(presence.Line2!);
                 PreviewL3.Text = TrimUTF8String(presence.ImageTooltip!);
+
+                PreviewListeningTo.Text = "Listening to ";
+                PreviewListeningTo.Text += Config.Settings.StatusDisplayType switch
+                {
+                    "State" => PreviewL2.Text,
+                    "Details" => PreviewL1.Text,
+                    _ => Config.Settings.DiscordListeningTo,
+                };
 
                 PreviewTime.Visibility = Visibility.Visible;
 
@@ -238,6 +246,7 @@ namespace PlexampRPC
                     State = TrimUTF8String(presence.Line2!),
                     Timestamps = new(DateTime.UtcNow, DateTime.UtcNow), // this is the least broken option to avoid any timer from showing I think
                     Type = ActivityType.Listening,
+                    StatusDisplay = Enum.Parse<StatusDisplayType>(Config.Settings.StatusDisplayType),
                     Assets = new() {
                         LargeImageKey = presence.ArtLink,
                         LargeImageText = TrimUTF8String(presence.ImageTooltip!),
@@ -250,6 +259,14 @@ namespace PlexampRPC
                 PreviewL1.Text = TrimUTF8String(presence.Line1!);
                 PreviewL2.Text = TrimUTF8String(presence.Line2!);
                 PreviewL3.Text = TrimUTF8String(presence.ImageTooltip!);
+
+                PreviewListeningTo.Text = "Listening to ";
+                PreviewListeningTo.Text += Config.Settings.StatusDisplayType switch
+                {
+                    "State" => PreviewL2.Text,
+                    "Details" => PreviewL1.Text,
+                    _ => Config.Settings.DiscordListeningTo,
+                };
 
                 PreviewTime.Visibility = Visibility.Collapsed;
                 PreviewPaused.Visibility = Visibility.Visible;
@@ -274,6 +291,14 @@ namespace PlexampRPC
                 .Replace("{title}", "Title")
                 .Replace("{artist}", "Artist")
                 .Replace("{album}", "Album");
+
+            PreviewListeningTo.Text = "Listening to ";
+			PreviewListeningTo.Text += Config.Settings.StatusDisplayType switch
+            {
+                "State" => PreviewL2.Text,
+                "Details" => PreviewL1.Text,
+                _ => Config.Settings.DiscordListeningTo,
+            };
 
             PreviewTime.Visibility = Visibility.Collapsed;
             PreviewPaused.Visibility = Visibility.Collapsed;

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -50,6 +50,13 @@
                 </StackPanel>
                 <Grid Height="10"/>
                 <StackPanel>
+                    <TextBlock TextWrapping="Wrap" Text="Status Display" Foreground="#FFF1F1F1" FontSize="14" Height="20" FontWeight="Bold" VerticalAlignment="Top"/>
+                    <RadioButton x:Name="RadioStatusName" Content="Name"/>
+                    <RadioButton x:Name="RadioStatusState" Content="State"/>
+                    <RadioButton x:Name="RadioStatusDetails" Content="Details"/>
+                </StackPanel>
+                <Grid Height="10"/>
+                <StackPanel>
                     <TextBlock TextWrapping="Wrap" Text="Template" Foreground="#FFF1F1F1" FontSize="14" Height="20" FontWeight="Bold" VerticalAlignment="Top"/>
                     <TextBox x:Name="TemplateL1" Margin="0 2 0 0" HorizontalAlignment="Stretch" Text="{Binding Path=(local:Config.TemplateL1), Mode=TwoWay}" ToolTip="{}{title}, {artist}, {album}"/>
                     <TextBox x:Name="TemplateL2" Margin="0 1 0 0" HorizontalAlignment="Stretch" Text="{Binding Path=(local:Config.TemplateL2), Mode=TwoWay}" ToolTip="{}{title}, {artist}, {album}"/>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -18,6 +18,7 @@ namespace PlexampRPC {
             StartupCheckBox.Unchecked += (_, _) => File.Delete(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "PlexampRPC.lnk"));
 
             SetupListeningTo();
+            SetupStatusDisplayType();
 
             MouseDown += (_, _) => FocusManager.SetFocusedElement(this, this);
 
@@ -35,6 +36,21 @@ namespace PlexampRPC {
                 RadioListeningMusic.IsChecked = true;
             else
                 RadioListeningCustom.IsChecked = true;
+        }
+
+        private void SetupStatusDisplayType() {
+            RadioStatusName.Checked += (_, _) => Config.Settings.StatusDisplayType = "Name";
+            RadioStatusState.Checked += (_, _) => Config.Settings.StatusDisplayType = "State";
+            RadioStatusDetails.Checked += (_, _) => Config.Settings.StatusDisplayType = "Details";
+
+            switch (Config.Settings.StatusDisplayType) {
+                case "State":
+                    RadioStatusState.IsChecked = true; break;
+                case "Details":
+                    RadioStatusDetails.IsChecked = true; break;
+                default:
+                    RadioStatusName.IsChecked = true; break;
+            }
         }
 
         private void StartOnStartup() {


### PR DESCRIPTION
This controls the one line preview people see in the status bar. It can be set to either the Name of the app, as it currently does and is the default, or it can be set to State (aka artist name) or Details (aka song name)

I have also removed the "by" from the default Template L2 text as it was causing it to say "Listening to by <artist>" when status display type was set to State

This fixes #32