### PR TITLE
Add support for local PlexAmp player

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -39,6 +39,7 @@ namespace PlexampRPC
         public string DiscordCustomClientID { get; set; } = "1100233636491563069";
 
         public string PlexAddress { get; set; } = string.Empty;
+        public bool LocalPlayer { get; set; }
     }
 
 

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -40,6 +40,7 @@
 
                     <CheckBox x:Name="OwnedCheckBox" Margin="0 0 0 0" Content="Owned Servers Only" IsChecked="{Binding Path=(local:Config.OwnedOnly), Mode=TwoWay}" ToolTip="Only adds servers to the list that belong to the authenticated Plex user"/>
 
+                    <CheckBox x:Name="LocalPlayerCheckBox" Margin="0 0 0 0" Content="Use Local Player" IsChecked="{Binding Path=(local:Config.LocalPlayer), Mode=TwoWay}" ToolTip="Poll the local PlexAmp player instead of querying the Plex server"/>
                 </StackPanel>
                 <Grid Height="10"/>
                 <StackPanel>


### PR DESCRIPTION
When enabling the "Use Local Player" option, the app will query your local PlexAmp API if running and enabled and display the same details as the server-based version, but will work with shared servers.

Unfortunately no album art with this version but we use the Plex app logo as default as it does when it fails to get the image on the server way.

<img width="565" height="467" alt="image" src="https://github.com/user-attachments/assets/5066ff3b-725e-4198-a11f-d4ff25737199" />